### PR TITLE
Upgrade branch 2.6.x using TemplateControl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'idea'
 }
 
-def playVersion = "2.6.11"
+def playVersion = "2.6.15"
 def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
 
 model {

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
   .aggregate(one, two)
   .dependsOn(one, two)
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 crossScalaVersions := Seq("2.11.12", "2.12.4")
 

--- a/modules/one/build.gradle
+++ b/modules/one/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'play'
 }
 
-def playVersion = "2.6.11"
+def playVersion = "2.6.15"
 def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
 
 model {

--- a/modules/one/build.sbt
+++ b/modules/one/build.sbt
@@ -1,2 +1,2 @@
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"

--- a/modules/one/project/build.properties
+++ b/modules/one/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Fri Jul 08 22:56:54 PDT 2016
 template.uuid=f57599cf-a4f5-4333-9ff1-55d48fd49891
-sbt.version=1.1.0
+sbt.version=1.1.2

--- a/modules/two/build.gradle
+++ b/modules/two/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'play'
 }
 
-def playVersion = "2.6.11"
+def playVersion = "2.6.15"
 def scalaVersion = System.getProperty("scala.binary.version", /* default = */ "2.12")
 
 model {

--- a/modules/two/build.sbt
+++ b/modules/two/build.sbt
@@ -1,2 +1,2 @@
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"

--- a/modules/two/project/build.properties
+++ b/modules/two/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Sun Jul 06 17:54:30 PDT 2014
 template.uuid=af582966-096a-43df-a504-5ddae8d4ebf1
-sbt.version=1.1.0
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
 


### PR DESCRIPTION
```
Updated with template-control on 2018-05-26T00:13:30.161Z
  **build.sbt:
    scalaVersion := "2.12.6"
  **build.sbt:
    scalaVersion := "2.12.6"
  **build.sbt:
    scalaVersion := "2.12.6"
  **/build.properties:
    sbt.version=1.1.1
  **/build.properties:
    sbt.version=1.1.1
  **/build.properties:
    sbt.version=1.1.1
  **/plugins.sbt:
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
  **build.gradle:
    def playVersion = "2.6.15"
  **build.gradle:
    def playVersion = "2.6.15"
  **build.gradle:
    def playVersion = "2.6.15"

```
          